### PR TITLE
Reset file input after import attempt

### DIFF
--- a/src/outbox.js
+++ b/src/outbox.js
@@ -134,6 +134,8 @@ const onStorageChanged = (changes, areaName) => {
 const onImportInputChanged = async ({ currentTarget }) => {
   try {
     const { files } = currentTarget;
+    if (files.length === 0) return;
+
     const [importedBackup] = files;
 
     if (importedBackup.type !== 'application/json') {
@@ -152,6 +154,7 @@ const onImportInputChanged = async ({ currentTarget }) => {
     await browser.storage.local.set(storageObject);
   } catch (exception) {
     window.alert(exception.toString());
+  } finally {
     currentTarget.value = currentTarget.defaultValue;
   }
 };


### PR DESCRIPTION
### User-facing changes
-  Triggering the file input twice in a row with the same file results in a UI update.

### Technical explanation
Mirroring https://github.com/AprilSylph/Palettes-for-Tumblr/pull/89, this resets the import `input` element after it is used to ensure that its onChange handler fires if you select the same file twice in a row.

### Issues this closes
n/a