### PR TITLE
fix: prevent duplicate saves by using both local variable and session storage

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -106,7 +106,7 @@ chrome.webRequest.onBeforeRequest.addListener(({ documentUrl, method, requestBod
 chrome.webRequest.onErrorOccurred.addListener(async ({ requestId }) => {
   const timeStamp =
     handledRequests.get(requestId) ??
-    await chrome.storage.session.get(requestId).then(({ [requestId]: timeStamp }) => timeStamp);
+    await chrome.storage.session.get('invalid value').then(({ [requestId]: timeStamp }) => timeStamp);
 
   if (timeStamp) {
     const { [timeStamp]: item } = await chrome.storage.local.get(timeStamp.toString());
@@ -125,7 +125,7 @@ chrome.webRequest.onErrorOccurred.addListener(async ({ requestId }) => {
 chrome.webRequest.onCompleted.addListener(async ({ requestId, statusCode }) => {
   const timeStamp =
     handledRequests.get(requestId) ??
-    await chrome.storage.session.get(requestId).then(({ [requestId]: timeStamp }) => timeStamp);
+    await chrome.storage.session.get('invalid value').then(({ [requestId]: timeStamp }) => timeStamp);
 
   if (/[45]\d\d/.test(statusCode) && timeStamp) {
     const { [timeStamp]: item } = await chrome.storage.local.get(timeStamp.toString());

--- a/src/background.js
+++ b/src/background.js
@@ -106,7 +106,7 @@ chrome.webRequest.onBeforeRequest.addListener(({ documentUrl, method, requestBod
 chrome.webRequest.onErrorOccurred.addListener(async ({ requestId }) => {
   const timeStamp =
     handledRequests.get(requestId) ??
-    await chrome.storage.session.get('invalid value').then(({ [requestId]: timeStamp }) => timeStamp);
+    await chrome.storage.session.get(requestId).then(({ [requestId]: timeStamp }) => timeStamp);
 
   if (timeStamp) {
     const { [timeStamp]: item } = await chrome.storage.local.get(timeStamp.toString());
@@ -125,7 +125,7 @@ chrome.webRequest.onErrorOccurred.addListener(async ({ requestId }) => {
 chrome.webRequest.onCompleted.addListener(async ({ requestId, statusCode }) => {
   const timeStamp =
     handledRequests.get(requestId) ??
-    await chrome.storage.session.get('invalid value').then(({ [requestId]: timeStamp }) => timeStamp);
+    await chrome.storage.session.get(requestId).then(({ [requestId]: timeStamp }) => timeStamp);
 
   if (/[45]\d\d/.test(statusCode) && timeStamp) {
     const { [timeStamp]: item } = await chrome.storage.local.get(timeStamp.toString());


### PR DESCRIPTION
See https://github.com/AprilSylph/Outbox-for-Tumblr/pull/101#issuecomment-2585239976 for background.

This semi-reverts the removal of the `handledRequests` map object, used in the background script scope to prevent multiple `onBeforeRequest` handlers from triggering on the same ask (same `requestId`) as well as to store the timestamp values for reference by the error handlers.

The use of `chrome.storage.session` that's added to handle the MV3 non-persistent background script is changed to be an **addition** on top of the previous storage method, handling only the case where the background script is unloaded during a network request, rather than a replacement.

This should prevent asks being saved multiple times. I think. Probably.

Reading this commit-by-commit may be more informative than looking at the diff as a whole.

### Testing steps

- If possible, check out the MV3 branch without this PR and confirm that duplicate asks are saved when sending an ask on tumblr.com/blogname.
- Check out this PR.
- Confirm that duplicate asks are not saved when sending an ask on tumblr.com/blogname.
- Confirm that asks are saved with an error when opening an ask to a blog you control on tumblr.com/blogname, disabling asks on that blog, and sending the ask.
- As in the test commit, break the `handledRequests.get(requestId)` lines in the error handling code to simulate the background script having been closed and reopened. Confirm that asks are still saved with an error when opening an ask to a blog you control on tumblr.com/blogname, disabling asks on that blog, and sending the ask.