### PR TITLE
chore: Remove outdated readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Save outgoing Tumblr asks automatically.
 ## Installation
 - [Get this extension for Firefox](https://addons.mozilla.org/addon/outbox-for-tumblr/)
 - [View on the Chrome Web Store](https://chrome.google.com/webstore/detail/oeamngjfgbhipkibmgglfdaohochpoej)
-- [View on Microsoft Edge Addons](https://microsoftedge.microsoft.com/addons/detail/fjcbfknblcnafnogblomfogebhilhiki)
-- [View on Opera add-ons](https://addons.opera.com/extensions/details/outbox-for-tumblr/)
 
 ## Usage
 Saving asks and answers is done passively. Open your outbox by clicking on the addon icon in the browser toolbar.


### PR DESCRIPTION
As noted in https://github.com/AprilSylph/Outbox-for-Tumblr/releases/tag/v2.0.0, the Edge and Opera extension store uploads are no longer maintained; this removes the links to them.