### PR TITLE
feat(UI): update layout dimensions

### DIFF
--- a/src/outbox.css
+++ b/src/outbox.css
@@ -191,7 +191,7 @@ main[data-show-limit-warning="true"]::before {
     width: 556px;
   }
 
-  aside:not(:empty) {
+  aside[aria-hidden="false"] {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
@@ -206,7 +206,7 @@ main[data-show-limit-warning="true"]::before {
     flex-grow: 0;
   }
 
-  aside div:last-child {
+  aside section div:last-child {
     margin-top: auto;
   }
 }
@@ -216,10 +216,8 @@ main[data-show-limit-warning="true"]::before {
   #base-container {
     flex-direction: row;
     align-items: flex-start;
-  }
-
-  main {
-    margin: 0 var(--post-margin);
+    column-gap: var(--post-margin);
+    padding-inline: var(--post-margin);
   }
 
   aside {
@@ -231,19 +229,11 @@ main[data-show-limit-warning="true"]::before {
     max-width: 360px;
     padding-bottom: var(--post-margin);
   }
-
-  aside:empty {
-    margin-left: var(--post-margin);
-  }
-
-  aside:not(:empty) {
-    margin-right: var(--post-margin);
-  }
 }
 
 /* Two-column layout | 100vw < (aside min width * 2) + main width + (--post-margin * 4) */
 @media not (min-width: 1180px) {
-  aside:empty {
+  aside[aria-hidden="true"] {
     display: none;
   }
 }

--- a/src/outbox.css
+++ b/src/outbox.css
@@ -1,4 +1,7 @@
 :root {
+  --main-width: 556px;
+  --aside-min-width: 270px;
+  --aside-max-width: 360px;
   --post-padding: 16px;
   --post-vertical-spacing: 15px;
   --post-margin: 16px;
@@ -127,7 +130,7 @@ body {
 main {
   flex-shrink: 0;
   box-sizing: border-box;
-  width: 556px;
+  width: var(--main-width);
   padding-bottom: var(--post-margin);
 }
 
@@ -173,13 +176,14 @@ main[data-show-limit-warning="true"]::before {
   white-space: pre-line;
 }
 
+/* Flush edges layout | 100vw ≤ --main-width */
 @media (max-width: 556px) {
   main[data-show-limit-warning="true"]::before {
     border-radius: 0;
   }
 }
 
-/* Single-column layout | 100vw < (aside min width + main width + (--post-margin * 3)) */
+/* Single-column layout | 100vw < (--aside-min-width + --main-width + (--post-margin * 3)) */
 @media not (min-width: 874px) {
   #base-container {
     flex-direction: column-reverse;
@@ -187,8 +191,8 @@ main[data-show-limit-warning="true"]::before {
   }
 
   aside {
-    height: 270px;
-    width: 556px;
+    height: var(--aside-min-width);
+    width: var(--main-width);
   }
 
   aside[aria-hidden="false"] {
@@ -201,7 +205,7 @@ main[data-show-limit-warning="true"]::before {
   }
 
   aside section {
-    flex-basis: 270px;
+    flex-basis: var(--aside-min-width);
     flex-shrink: 0;
     flex-grow: 0;
   }
@@ -211,7 +215,7 @@ main[data-show-limit-warning="true"]::before {
   }
 }
 
-/* Multi-column layout | 100vw ≥ (aside min width + main width + (--post-margin * 3)) */
+/* Multi-column layout | 100vw ≥ (--aside-min-width + --main-width + (--post-margin * 3)) */
 @media (min-width: 874px) {
   #base-container {
     flex-direction: row;
@@ -224,7 +228,7 @@ main[data-show-limit-warning="true"]::before {
     position: sticky;
     top: 0;
 
-    flex-basis: 360px;
+    flex-basis: var(--aside-max-width);
     flex-grow: 0;
     padding-bottom: var(--post-margin);
   }
@@ -233,7 +237,7 @@ main[data-show-limit-warning="true"]::before {
   aside[aria-hidden="false"] { flex-shrink: 0; }
 }
 
-/* Two-column layout | 100vw < (aside max width + main width + (--post-margin * 4)) */
+/* Two-column layout | 100vw < (--aside-max-width + --main-width + (--post-margin * 4)) */
 @media not (min-width: 980px) {
   aside[aria-hidden="true"] { display: none; }
   aside[aria-hidden="false"] { flex-shrink: 1; }
@@ -360,6 +364,7 @@ article {
   outline: 1px solid var(--content-panel-border);
 }
 
+/* Flush edges layout | 100vw ≤ --main-width */
 @media (max-width: 556px) {
   article {
     border-radius: 12px;
@@ -552,7 +557,7 @@ article footer button:focus-visible {
 }
 
 [data-block="video"] iframe {
-  --post-width: min(556px, 100vw);
+  --post-width: min(var(--main-width), 100vw);
   height: calc(var(--post-width) * var(--aspect-ratio, calc(9 / 16)));
 }
 

--- a/src/outbox.css
+++ b/src/outbox.css
@@ -179,8 +179,8 @@ main[data-show-limit-warning="true"]::before {
   }
 }
 
-/* Single-column layout | 100vw < aside min width + main width + (--post-margin * 3) */
-@media not (min-width: 884px) {
+/* Single-column layout | 100vw < (aside min width + main width + (--post-margin * 3)) */
+@media not (min-width: 874px) {
   #base-container {
     flex-direction: column-reverse;
     align-items: center;
@@ -211,8 +211,8 @@ main[data-show-limit-warning="true"]::before {
   }
 }
 
-/* Multi-column layout | 100vw ≥ aside min width + main width + (--post-margin * 3) */
-@media (min-width: 884px) {
+/* Multi-column layout | 100vw ≥ (aside min width + main width + (--post-margin * 3)) */
+@media (min-width: 874px) {
   #base-container {
     flex-direction: row;
     align-items: flex-start;
@@ -224,18 +224,19 @@ main[data-show-limit-warning="true"]::before {
     position: sticky;
     top: 0;
 
-    flex: 1;
-    min-width: 280px;
-    max-width: 360px;
+    flex-basis: 360px;
+    flex-grow: 0;
     padding-bottom: var(--post-margin);
   }
+
+  aside[aria-hidden="true"] { flex-shrink: 1; }
+  aside[aria-hidden="false"] { flex-shrink: 0; }
 }
 
-/* Two-column layout | 100vw < (aside min width * 2) + main width + (--post-margin * 4) */
-@media not (min-width: 1180px) {
-  aside[aria-hidden="true"] {
-    display: none;
-  }
+/* Two-column layout | 100vw < (aside max width + main width + (--post-margin * 4)) */
+@media not (min-width: 980px) {
+  aside[aria-hidden="true"] { display: none; }
+  aside[aria-hidden="false"] { flex-shrink: 1; }
 }
 
 /* Sidebar */

--- a/src/outbox.css
+++ b/src/outbox.css
@@ -125,6 +125,7 @@ body {
 }
 
 main {
+  flex-shrink: 0;
   box-sizing: border-box;
   width: 556px;
   padding-bottom: var(--post-margin);
@@ -178,8 +179,8 @@ main[data-show-limit-warning="true"]::before {
   }
 }
 
-/* Single-column layout | 100vw < aside width + main width + (--post-margin * 3) */
-@media not (min-width: 904px) {
+/* Single-column layout | 100vw < aside min width + main width + (--post-margin * 3) */
+@media not (min-width: 884px) {
   #base-container {
     flex-direction: column-reverse;
     align-items: center;
@@ -190,7 +191,7 @@ main[data-show-limit-warning="true"]::before {
     width: 556px;
   }
 
-  aside:last-child {
+  aside:not(:empty) {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
@@ -210,8 +211,8 @@ main[data-show-limit-warning="true"]::before {
   }
 }
 
-/* Multi-column layout | 100vw ≥ aside width + main width + (--post-margin * 3) */
-@media (min-width: 904px) {
+/* Multi-column layout | 100vw ≥ aside min width + main width + (--post-margin * 3) */
+@media (min-width: 884px) {
   #base-container {
     flex-direction: row;
     align-items: flex-start;
@@ -224,21 +225,24 @@ main[data-show-limit-warning="true"]::before {
   aside {
     position: sticky;
     top: 0;
-    width: 300px;
+
+    flex: 1;
+    min-width: 280px;
+    max-width: 360px;
     padding-bottom: var(--post-margin);
   }
 
-  aside:first-child {
+  aside:empty {
     margin-left: var(--post-margin);
   }
 
-  aside:last-child {
+  aside:not(:empty) {
     margin-right: var(--post-margin);
   }
 }
 
-/* Two-column layout | 100vw < (aside width * 2) + main width + (--post-margin * 4) */
-@media not (min-width: 1220px) {
+/* Two-column layout | 100vw < (aside min width * 2) + main width + (--post-margin * 4) */
+@media not (min-width: 1180px) {
   aside:empty {
     display: none;
   }

--- a/src/outbox.css
+++ b/src/outbox.css
@@ -126,7 +126,7 @@ body {
 
 main {
   box-sizing: border-box;
-  width: 540px;
+  width: 556px;
   padding-bottom: var(--post-margin);
 }
 
@@ -172,22 +172,22 @@ main[data-show-limit-warning="true"]::before {
   white-space: pre-line;
 }
 
-@media (max-width: 540px) {
+@media (max-width: 556px) {
   main[data-show-limit-warning="true"]::before {
     border-radius: 0;
   }
 }
 
-/* Single-column layout | 100vw > aside width + main width + (--post-margin * 3) */
-@media not (min-width: 888px) {
+/* Single-column layout | 100vw < aside width + main width + (--post-margin * 3) */
+@media not (min-width: 904px) {
   #base-container {
     flex-direction: column-reverse;
     align-items: center;
   }
 
   aside {
-    height: 264px;
-    width: 540px;
+    height: 270px;
+    width: 556px;
   }
 
   aside:last-child {
@@ -195,12 +195,12 @@ main[data-show-limit-warning="true"]::before {
     flex-direction: row;
     justify-content: space-between;
     align-items: stretch;
-    column-gap: 12px;
+    column-gap: var(--post-margin);
     overflow-x: auto;
   }
 
   aside section {
-    flex-basis: 264px;
+    flex-basis: 270px;
     flex-shrink: 0;
     flex-grow: 0;
   }
@@ -211,7 +211,7 @@ main[data-show-limit-warning="true"]::before {
 }
 
 /* Multi-column layout | 100vw ≥ aside width + main width + (--post-margin * 3) */
-@media (min-width: 888px) {
+@media (min-width: 904px) {
   #base-container {
     flex-direction: row;
     align-items: flex-start;
@@ -238,7 +238,7 @@ main[data-show-limit-warning="true"]::before {
 }
 
 /* Two-column layout | 100vw < (aside width * 2) + main width + (--post-margin * 4) */
-@media not (min-width: 1204px) {
+@media not (min-width: 1220px) {
   aside:empty {
     display: none;
   }
@@ -365,7 +365,7 @@ article {
   outline: 1px solid var(--content-panel-border);
 }
 
-@media (max-width: 540px) {
+@media (max-width: 556px) {
   article {
     border-radius: 12px;
   }
@@ -557,7 +557,7 @@ article footer button:focus-visible {
 }
 
 [data-block="video"] iframe {
-  --post-width: min(540px, 100vw);
+  --post-width: min(556px, 100vw);
   height: calc(var(--post-width) * var(--aspect-ratio, calc(9 / 16)));
 }
 

--- a/src/outbox.html
+++ b/src/outbox.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-GB">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -15,9 +15,9 @@
   <body>
     <input id="file-input" type="file" accept="application/json" hidden>
     <div id="base-container">
-      <aside></aside>
+      <aside aria-hidden="true"></aside>
       <main aria-busy="true"></main>
-      <aside>
+      <aside aria-hidden="false">
         <section id="backup">
           <h1>Backup</h1>
           <ul>


### PR DESCRIPTION
### Description

Before | After
-|-
<img width="3840" height="2400" alt="Screen Shot 2026-05-07 at 11 34 10" src="https://github.com/user-attachments/assets/0af01438-0948-4685-a692-7153b5b71395" /> | <img width="3840" height="2400" alt="Screen Shot 2026-05-07 at 11 34 32" src="https://github.com/user-attachments/assets/f1dba9db-8111-49e3-a577-14c3a5a17648" />
<img width="3840" height="2400" alt="Screen Shot 2026-05-07 at 11 34 13" src="https://github.com/user-attachments/assets/a53606f6-b508-45f3-a49e-5a6498b64b53" /> | <img width="3840" height="2400" alt="Screen Shot 2026-05-07 at 11 34 37" src="https://github.com/user-attachments/assets/9db4137f-5fd6-4d77-9b21-c87ca258e99b" />

...yeah, no, I don't like the sidebar width change.

The light mode "Before" screenshot is the nicest-looking one in the grid, to my eyes at least...

The post width change also kinda doesn't make sense without the media padding changes.

### Testing steps

N/A
