### PR TITLE
feat(UI): use design system tokens for spacing

### DIFF
--- a/src/outbox.css
+++ b/src/outbox.css
@@ -1,7 +1,13 @@
 :root {
-  --post-padding: 16px;
-  --post-vertical-spacing: 15px;
-  --post-margin: 16px;
+  --space-xxxs: 2px;
+  --space-xxs: 4px;
+  --space-xs: 8px;
+  --space-s: 12px;
+  --space-m: 16px;
+  --space-l: 20px;
+  --space-xl: 24px;
+  --space-xxl: 28px;
+  --space-xxxl: 32px;
 
   --accent: rgba(0, 184, 255, 1);
   --accent-tint: rgba(0, 184, 255, 0.1);
@@ -68,7 +74,8 @@ p,
 blockquote,
 ul,
 ol {
-  margin: var(--post-vertical-spacing) 0;
+  margin-block: 15px;
+  margin-inline: 0;
 }
 
 a {
@@ -80,13 +87,13 @@ iframe { display: block; }
 small { font-size: 0.8125em; }
 
 blockquote {
-  padding-left: var(--post-padding);
+  padding-left: var(--space-m);
   border-left: 3px solid var(--content-tint-strong);
 }
 
 ul,
 ol {
-  padding-left: var(--post-padding);
+  padding-left: var(--space-m);
 }
 
 ul {
@@ -109,7 +116,7 @@ video {
 html {
   font-size: 16px;
   line-height: 1.5;
-  scroll-padding-top: var(--post-margin);
+  scroll-padding-top: var(--space-m);
 }
 
 body {
@@ -127,7 +134,7 @@ body {
 main {
   box-sizing: border-box;
   width: 540px;
-  padding-bottom: var(--post-margin);
+  padding-bottom: var(--space-m);
 }
 
 main:empty {
@@ -135,9 +142,9 @@ main:empty {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 100px var(--post-padding);
+  padding: 100px var(--space-m);
   border-radius: 8px;
-  margin-top: var(--post-margin);
+  margin-top: var(--space-m);
 
   background-color: var(--chrome-panel);
   text-align: center;
@@ -164,7 +171,7 @@ main[data-show-limit-warning="true"]::before {
   display: block;
   padding: 14px 16px;
   border-radius: 8px;
-  margin-top: var(--post-margin);
+  margin-top: var(--space-m);
 
   background-color: var(--brand-orange);
   color: var(--color-fg-light);
@@ -178,7 +185,7 @@ main[data-show-limit-warning="true"]::before {
   }
 }
 
-/* Single-column layout | 100vw > aside width + main width + (--post-margin * 3) */
+/* Single-column layout | 100vw > aside width + main width + (--space-m * 3) */
 @media not (min-width: 888px) {
   #base-container {
     flex-direction: column-reverse;
@@ -210,7 +217,7 @@ main[data-show-limit-warning="true"]::before {
   }
 }
 
-/* Multi-column layout | 100vw ≥ aside width + main width + (--post-margin * 3) */
+/* Multi-column layout | 100vw ≥ aside width + main width + (--space-m * 3) */
 @media (min-width: 888px) {
   #base-container {
     flex-direction: row;
@@ -218,26 +225,26 @@ main[data-show-limit-warning="true"]::before {
   }
 
   main {
-    margin: 0 var(--post-margin);
+    margin: 0 var(--space-m);
   }
 
   aside {
     position: sticky;
     top: 0;
     width: 300px;
-    padding-bottom: var(--post-margin);
+    padding-bottom: var(--space-m);
   }
 
   aside:first-child {
-    margin-left: var(--post-margin);
+    margin-left: var(--space-m);
   }
 
   aside:last-child {
-    margin-right: var(--post-margin);
+    margin-right: var(--space-m);
   }
 }
 
-/* Two-column layout | 100vw < (aside width * 2) + main width + (--post-margin * 4) */
+/* Two-column layout | 100vw < (aside width * 2) + main width + (--space-m * 4) */
 @media not (min-width: 1204px) {
   aside:empty {
     display: none;
@@ -253,14 +260,16 @@ aside section {
   box-sizing: border-box;
   border: 1px solid var(--chrome-panel-border);
   border-radius: 12px;
-  margin-top: var(--post-margin);
+  margin-top: var(--space-m);
 
   background-color: var(--chrome-panel);
   color: var(--chrome-fg);
 }
 
 aside h1 {
-  padding: var(--post-padding) var(--post-padding) var(--post-vertical-spacing);
+  padding-block-start: var(--space-l);
+  padding-block-end: var(--space-m);
+  padding-inline: var(--space-l);
   margin: 0;
 
   font-size: 1rem;
@@ -269,14 +278,16 @@ aside h1 {
 }
 
 aside ul {
-  padding: 0 calc(var(--post-padding) / 2) var(--post-vertical-spacing);
+  padding-block-end: var(--space-m);
+  padding-inline: var(--space-xs);
   margin: 0;
 
   list-style-type: none;
 }
 
 aside div {
-  padding: 0 var(--post-padding) var(--post-vertical-spacing);
+  padding-block-end: var(--space-m);
+  padding-inline: var(--space-l);
   margin: 0;
 }
 
@@ -297,7 +308,9 @@ aside :is(a, button) {
 
   box-sizing: border-box;
   width: 100%;
-  padding: calc(var(--post-padding) / 2);
+  padding-block: var(--space-xs);
+  padding-inline-start: var(--space-s);
+  padding-inline-end: var(--space-xs);
   border-radius: 8px;
 
   text-decoration: none;
@@ -325,7 +338,8 @@ aside p {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  margin: calc(var(--post-padding) / 2) 0 0;
+  margin-block-start: var(--space-xs);
+  margin-block-end: 0;
 }
 
 aside small {
@@ -353,13 +367,13 @@ aside small {
 /* Main */
 
 main > p {
-  margin: var(--post-margin) 0;
+  margin: var(--space-m) 0;
 }
 
 article {
   border-radius: 8px;
-  padding: var(--post-padding);
-  margin-top: var(--post-margin);
+  padding: var(--space-m);
+  margin-top: var(--space-m);
 
   background-color: var(--content-panel);
   outline: 1px solid var(--content-panel-border);
@@ -376,7 +390,7 @@ article:focus-visible {
 }
 
 article header {
-  margin-bottom: var(--post-vertical-spacing);
+  margin-bottom: 14px;
 
   color: var(--content-fg-secondary);
   font-size: .875rem;
@@ -400,9 +414,9 @@ article header a {
 
 article section.error {
   max-width: none;
-  padding: 0.5ch var(--post-padding);
-  margin-left: calc(0px - var(--post-padding));
-  margin-right: calc(0px - var(--post-padding));
+  padding: 0.5ch var(--space-m);
+  margin-left: calc(0px - var(--space-m));
+  margin-right: calc(0px - var(--space-m));
 
   background-color: var(--danger);
   color: white;
@@ -412,14 +426,14 @@ article section.error {
 .ask-wrapper {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 40px;
-  grid-column-gap: var(--post-vertical-spacing);
-  margin: var(--post-vertical-spacing) 0;
+  grid-column-gap: 18px;
+  margin-block: var(--space-s);
 }
 
 .ask {
   position: relative;
 
-  padding: 0 var(--post-padding);
+  padding-inline: var(--space-m);
   border-radius: 3px;
   border-top: 1px solid transparent;
   border-bottom: 1px solid transparent;
@@ -443,7 +457,7 @@ article section.error {
 
 .ask [data-attribution="blog"]:first-child {
   display: block;
-  margin: var(--post-vertical-spacing) 0;
+  margin-block: var(--space-s);
 
   color: var(--content-fg-secondary);
   font-size: .875rem;
@@ -458,17 +472,13 @@ article section.error {
   content: " asked:";
 }
 
-p {
-  margin: var(--post-vertical-spacing) 0;
-}
-
 article footer {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  padding-top: var(--post-vertical-spacing);
-  margin-top: var(--post-padding);
+  padding-top: var(--space-xs);
+  margin-top: var(--space-m);
 }
 
 article footer time {
@@ -513,8 +523,8 @@ article footer button:focus-visible {
 [data-block="audio"],
 [data-block="video"] {
   max-width: none;
-  margin-left: calc(0px - var(--post-padding));
-  margin-right: calc(0px - var(--post-padding));
+  margin-left: calc(0px - var(--space-m));
+  margin-right: calc(0px - var(--space-m));
 }
 
 [data-row] > [data-block] {
@@ -522,16 +532,22 @@ article footer button:focus-visible {
   margin-right: 0;
 }
 
+[data-block="image"] img {
+  display: block;
+}
+
 [data-block="image"] figcaption {
-  padding: 0 var(--post-padding);
-  margin: calc(var(--post-vertical-spacing) / 2) 0;
+  padding: 0 var(--space-m);
+  margin-block-start: var(--space-xs);
+  margin-block-end: 0;
 }
 
 [data-block="link"] {
   border: 1px solid var(--content-tint-strong);
   border-radius: 7px;
   overflow: hidden;
-  margin: var(--post-vertical-spacing) 0;
+  margin-block: 15px;
+  margin-inline: 0;
 }
 
 [data-block="link"] figure {
@@ -563,9 +579,9 @@ article footer button:focus-visible {
 
 [data-attribution="post"],
 [data-attribution="app"] {
-  padding: 0 var(--post-padding);
-  margin-top: calc(var(--post-vertical-spacing) / 2);
-  margin-bottom: var(--post-vertical-spacing);
+  padding-block: 0;
+  padding-inline: var(--space-m);
+  margin-block: var(--space-xxs);
 
   color: var(--content-fg-secondary);
   text-align: end;
@@ -575,7 +591,7 @@ article footer button:focus-visible {
 [data-attribution="link"] {
   display: block;
   overflow: hidden;
-  padding: 0 var(--post-padding);
+  padding: 0 var(--space-m);
 
   background-color: var(--content-tint-strong);
   color: var(--content-fg-secondary);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
And now starts again the work to make the outbox mimic the dashboard more closely.
First up: spacing tokens. One of the basics; we'll be making more use of these later.

I probably should have split this into multiple commits... sorry.

- Adds the Tumblr design system spacing tokens
- Replaces all usages of the old variables `--post-padding` and `--post-margin` with `--space-m`
- Updates the spacing of a few elements to match their Tumblr equivalents (a.k.a. The Great Spacing Sync)
  - Notable mentions: the sidebar, ask wrappers, article footers
- Drops `--post-vertical-spacing` entirely; the 15px value is now only used in two places after The Great Spacing Sync

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->
Before | After
-|-
<img width="3840" height="2400" alt="Screen Shot 2026-07-15 at 11 00 07" src="https://github.com/user-attachments/assets/c2b7e467-e85d-4679-b269-39be77e49f07" /> | <img width="3840" height="2400" alt="Screen Shot 2026-07-15 at 11 01 41" src="https://github.com/user-attachments/assets/4fa36f51-f17d-4e4e-9dd7-ea4493fee2f0" />
<img width="3840" height="2400" alt="Screen Shot 2026-07-15 at 11 00 13" src="https://github.com/user-attachments/assets/84409ca5-0f3b-4b03-9e61-d7e72567eb42" /> | <img width="3840" height="2400" alt="Screen Shot 2026-07-15 at 11 01 45" src="https://github.com/user-attachments/assets/58ea989a-26f4-498b-b804-b70f9e07239f" />

Before | After | Before | After
-|-|-|-
<img width="2400" height="3840" alt="Screen Shot 2026-07-15 at 11 00 51" src="https://github.com/user-attachments/assets/13509f5e-3bc3-422d-a603-1b1d93dcab9b" /> | <img width="2400" height="3840" alt="Screen Shot 2026-07-15 at 11 01 58" src="https://github.com/user-attachments/assets/99d39ad7-126a-4840-bd8b-8d7fd30109e6" /> | <img width="2400" height="3840" alt="Screen Shot 2026-07-15 at 11 00 54" src="https://github.com/user-attachments/assets/ac92216e-fd29-41fa-bc72-f7955fff8209" /> | <img width="2400" height="3840" alt="Screen Shot 2026-07-15 at 11 02 02" src="https://github.com/user-attachments/assets/348cbf8f-2430-4875-9990-4f3790680ebd" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a backup file to test with, if applicable.
-->
1. Load the modified addon
2. Import a bunch of varied asks/answers (hopefully you use this addon casually, too?)
    - **Expected result**: None of the element spacing looks weird or broken
