### PR TITLE
chore: Set `allowScripts` package value for npm 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   "dependencies": {
     "normalize.css": "^8.0.1"
   },
+  "allowScripts": {
+    "unrs-resolver": false
+  },
   "webExt": {
     "sourceDir": "src/",
     "build": {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

npm 12 has the breaking change that dependency postinstall scripts are blocked unless explicitly allowed. This project has one relevant dependency: `unrs-resolver`'s seems unnecessary (see https://github.com/AprilSylph/XKit-Rewritten/pull/2315). So this doesn't really do anything besides quieting the warning on install.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

n/a

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a backup file to test with, if applicable.
-->

- Delete node_modules. `npm install` and `npm run posttest`.
- If desired, do this with both npm@11 and npm@12 (`npm install -g npm`).