### PR TITLE
fix(NPF): select correct asset size for rendering image blocks

### DIFF
--- a/src/lib/npf.js
+++ b/src/lib/npf.js
@@ -89,12 +89,15 @@ const blockRenderers = {
     return document.createElement('figure').tap(figure => {
       figure.append(document.createElement('img').tap(img => {
         alt_text && (img.alt = img.title = alt_text);
+        img.loading = 'lazy';
+        img.sizes = 'auto';
         img.src = media[0].url;
         img.srcset = media
           .filter(({ cropped }) => !cropped)
-          .reverse()
+          .toReversed()
           .map(({ url, width }) => `${url} ${width}w`)
-          .join(',\n');
+          .join(', ');
+        img.style.aspectRatio = `${media[0].width} / ${media[0].height}`;
       }));
 
       if (attribution) figure.append(renderAttribution(attribution));


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
Makes image blocks select the correct asset size to download, based on the size of the image element and the current DPI. This is achieved through setting `loading="lazy"` and `sizes="auto"`, which by themselves change the intrinsic height of the elements, but this is easily corrected by setting the CSS `aspect-ratio` per image.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->
Before | After
-|-
<img width="2160" height="1234" alt="Screenshot 2026-07-17 at 3 58 54 pm" src="https://github.com/user-attachments/assets/215cfb92-6da2-44c3-b85a-e6fe077c2595" /> | <img width="2160" height="1234" alt="Screenshot 2026-07-17 at 3 59 17 pm" src="https://github.com/user-attachments/assets/80ed95b8-150c-41e5-992f-895720fc9ba1" />
Without `sizes`, the highest-resolution image is chosen, even with a simulated low DPI. | With `sizes="auto"` and a simulated low DPI, a lower-resolution image size is chosen.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a backup file to test with, if applicable.
-->
1. Load the modified addon
2. On Tumblr, send a large image (at least 2048px wide) via an ask
3. View the sent ask in your outbox
    - **Expected result**: With DPI: 1, the image size selected is 500px (≥ 450px × DPI = 450px)
    - **Expected result**: With DPI: 2, the image size selected is 1280px (≥ 450px × DPI = 900px)
    - **Expected result**: With DPI: 3, the image size selected is 2048px (≥ 450px × DPI = 1350px)
4. On Tumblr, send a large image via a private answer
5. View the sent private answer in your outbox
    - **Expected result**: With DPI: 1, the image size selected is 540px (≥ 540px × DPI = 540px)
    - **Expected result**: With DPI: 2, the image size selected is 1280px (≥ 540px × DPI = 1280px)
    - **Expected result**: With DPI: 3, the image size selected is 2048px (≥ 540px × DPI = 1620px)
