### PR TITLE
feat(UI): update image block attribution styling

### DIFF
--- a/src/lib/npf.js
+++ b/src/lib/npf.js
@@ -306,7 +306,7 @@ const attributionRenderers = {
   post: ({ url, blog: { name, uuid } }) => document.createElement('a').tap(a => {
     Object.assign(a, { href: url, target: '_blank' });
     a.append(
-      'Originally posted by ',
+      'GIF by ',
       Object.assign(document.createElement('strong'), { textContent: name || uuid })
     );
   }),
@@ -314,7 +314,7 @@ const attributionRenderers = {
   link: ({ url }) => Object.assign(document.createElement('a'), {
     href: url,
     target: '_blank',
-    textContent: url
+    textContent: URL.canParse(url) ? new URL(url).hostname : url
   }),
 
   blog: ({ blog: { url, title, name, uuid } }) => document.createElement('p').tap(p => p.append(

--- a/src/outbox.css
+++ b/src/outbox.css
@@ -10,6 +10,7 @@
   --space-xxxl: 32px;
 
   --accent: rgba(0, 184, 255, 1);
+  --accent-hover: rgba(51, 198, 255, 1);
   --accent-tint: rgba(0, 184, 255, 0.1);
   --chrome: rgba(26, 48, 73, 1);
   --chrome-panel: rgba(38, 59, 83, 1);
@@ -35,6 +36,7 @@
 @media (prefers-color-scheme: dark) {
   :root {
     --accent: rgba(0, 184, 255, 1);
+    --accent-hover: rgba(51, 198, 255, 1);
     --accent-tint: rgba(0, 184, 255, 0.1);
     --chrome: rgba(13, 13, 13, 1);
     --chrome-panel: rgba(26, 26, 26, 1);
@@ -537,9 +539,8 @@ article footer button:focus-visible {
 }
 
 [data-block="image"] figcaption {
-  padding: 0 var(--space-m);
-  margin-block-start: var(--space-xs);
-  margin-block-end: 0;
+  padding-inline: var(--space-m);
+  margin-block: var(--space-xs);
 }
 
 [data-block="link"] {
@@ -577,49 +578,53 @@ article footer button:focus-visible {
   height: calc(var(--post-width) * var(--aspect-ratio, calc(9 / 16)));
 }
 
-[data-attribution="post"],
-[data-attribution="app"] {
-  padding-block: 0;
-  padding-inline: var(--space-m);
-  margin-block: var(--space-xxs);
-
-  color: var(--content-fg-secondary);
-  text-align: end;
-  text-decoration: none;
-}
-
-[data-attribution="link"] {
+:is([data-attribution="post"], [data-attribution="link"], [data-attribution="app"]) {
   display: block;
+  padding-inline: var(--space-xs);
+  margin-block: var(--space-xs);
   overflow: hidden;
-  padding: 0 var(--space-m);
 
-  background-color: var(--content-tint-strong);
   color: var(--content-fg-secondary);
-  font-size: 0.875rem;
-  line-height: 1.875rem;
+  font-size: 0.75rem;
+  line-height: 1.125rem;
   text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-[data-attribution="link"]:hover {
-  background-color: var(--accent-tint);
-  color: var(--accent);
+:is([data-attribution="post"], [data-attribution="link"], [data-attribution="app"]):hover {
+  color: var(--accent-hover);
 }
 
-[data-attribution="app"][data-has-logo] {
+[data-attribution="post"] {
+  text-align: end;
+}
+
+:is([data-attribution="link"], [data-attribution="app"])::after {
+  display: inline-flex;
+  justify-content: center;
+  width: 1.125rem;
+
+  content: '\276F';
+  font-weight: bold;
+}
+
+[data-attribution="app"]:has(img) {
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
   align-items: center;
-  padding: 0 0.5ch;
+  column-gap: var(--space-xxs);
+}
+
+[data-attribution="app"]:has(img)::after {
+  content: none;
 }
 
 [data-attribution="app"] img {
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 1.125rem;
+  height: 1.125rem;
   border-radius: 3px;
-  margin-left: 0.5ch;
 }
 
 article details summary {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
Updates the look of image block attribution to mimic the new styles of these elements within Tumblr, including verbiage changes:
- for post-type attribution: "Originally posted by" &rarr; "GIF by"
- for link-type attribution: full URL, truncated &rarr; hostname of URL only

Also includes code changes for image block captions and app-type attribution with logo (both unused). I did test these changes visually, albeit without real post data.

The mimicry is not 1:1 due to the various issues that these elements have on Tumblr; instead, it should look like we're the blueprint that Tumblr is badly imitating.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

<details><summary><strong>Expand</strong></summary>

<br>

Before | After
-|-
<img width="1620" height="1962" alt="Screen Shot 2026-07-22 at 10 39 12" src="https://github.com/user-attachments/assets/762bfb97-a20b-41b4-b997-344b5c2a2e9f" /> | <img width="1620" height="1962" alt="Screen Shot 2026-07-22 at 10 41 48" src="https://github.com/user-attachments/assets/d65518f5-98e9-49d0-affa-3153d1d4826b" />
<img width="1620" height="1962" alt="Screen Shot 2026-07-22 at 10 39 38" src="https://github.com/user-attachments/assets/8eb1a976-93f6-48e2-bc05-c11bed868dff" /> | <img width="1620" height="1962" alt="Screen Shot 2026-07-22 at 10 42 00" src="https://github.com/user-attachments/assets/84835301-6a5e-4e22-9883-8bcf4215d60f" />
<img width="1620" height="1956" alt="Screen Shot 2026-07-22 at 10 39 55" src="https://github.com/user-attachments/assets/b9734008-96fd-440b-a9ec-c6c7247bde3b" /> | <img width="1620" height="1962" alt="Screen Shot 2026-07-22 at 10 42 08" src="https://github.com/user-attachments/assets/00c4610d-ab92-4167-91c2-8511d1384a5a" />
<img width="1620" height="1956" alt="Screen Shot 2026-07-22 at 10 40 08" src="https://github.com/user-attachments/assets/98e6d8b1-aeb2-45bd-a938-486e0b6358ce" /> | <img width="1620" height="1962" alt="Screen Shot 2026-07-22 at 10 42 18" src="https://github.com/user-attachments/assets/7e4f5eb5-8882-4e1f-bff4-282fe7498833" />
<img width="1620" height="2196" alt="Screen Shot 2026-07-22 at 10 55 53" src="https://github.com/user-attachments/assets/f986d9dd-9c22-42ca-b0df-a55f2395e585" /> | <img width="1620" height="2202" alt="Screen Shot 2026-07-22 at 10 56 18" src="https://github.com/user-attachments/assets/fc4084e8-a58f-4be4-aebd-335d233ffcda" />
<img width="1620" height="2196" alt="Screen Shot 2026-07-22 at 10 56 02" src="https://github.com/user-attachments/assets/c5f070bb-668e-4f6f-a273-a884384edb98" /> | <img width="1620" height="2202" alt="Screen Shot 2026-07-22 at 10 56 28" src="https://github.com/user-attachments/assets/27f503a5-f8cf-4410-999b-51c5660b5621" />

</details>

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a backup file to test with, if applicable.
-->
Code review and visual comparison will suffice.
