### PR TITLE
feat(UI): update post/media dimensions

### DIFF
--- a/src/lib/npf.css
+++ b/src/lib/npf.css
@@ -67,6 +67,7 @@
 [data-row] {
   display: flex;
   flex-direction: row;
+  column-gap: 4px;
 }
 
 [data-block],
@@ -76,15 +77,6 @@
 
 [data-row] > [data-block] {
   flex: 1;
-  padding: 0 2px;
-}
-
-[data-row] > [data-block]:first-child {
-  padding-left: 0;
-}
-
-[data-row] > [data-block]:last-child {
-  padding-right: 0;
 }
 
 [data-block="text"] {

--- a/src/outbox.css
+++ b/src/outbox.css
@@ -541,6 +541,44 @@ article footer button:focus-visible {
 
 [data-block="image"] img {
   display: block;
+  border-radius: 4px;
+
+  outline: 1px solid var(--content-tint-strong);
+  outline-offset: -1px;
+}
+
+[data-block="image"]:has(+ :is([data-row], [data-block="image"])) img {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+:is([data-row], [data-block="image"]) + [data-block="image"] img {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+[data-row] > [data-block="image"] img {
+  border-radius: 4px;
+}
+
+[data-row] > [data-block="image"]:has(+ [data-block="image"]) img {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+[data-row] > [data-block="image"] + [data-block="image"] img {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+[data-row]:has(+ :is([data-row], [data-block="image"])) > [data-block="image"] img {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+:is([data-row], [data-block="image"]) + [data-row] > [data-block="image"] img {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 [data-block="image"] figcaption {
@@ -575,6 +613,13 @@ article footer button:focus-visible {
   font-size: 0.78125rem;
   font-weight: 400;
   text-transform: uppercase;
+}
+
+[data-block="video"] :is(iframe, video) {
+  border-radius: 4px;
+
+  outline: 1px solid var(--content-tint-strong);
+  outline-offset: -1px;
 }
 
 [data-block="video"] iframe {

--- a/src/outbox.css
+++ b/src/outbox.css
@@ -135,7 +135,7 @@ body {
 
 main {
   box-sizing: border-box;
-  width: 540px;
+  width: 556px;
   padding-bottom: var(--space-m);
 }
 
@@ -181,7 +181,7 @@ main[data-show-limit-warning="true"]::before {
   white-space: pre-line;
 }
 
-@media (max-width: 540px) {
+@media (max-width: 556px) {
   main[data-show-limit-warning="true"]::before {
     border-radius: 0;
   }
@@ -195,8 +195,8 @@ main[data-show-limit-warning="true"]::before {
   }
 
   aside {
-    height: 264px;
-    width: 540px;
+    height: 272px;
+    width: 556px;
   }
 
   aside:last-child {
@@ -209,7 +209,7 @@ main[data-show-limit-warning="true"]::before {
   }
 
   aside section {
-    flex-basis: 264px;
+    flex-basis: 272px;
     flex-shrink: 0;
     flex-grow: 0;
   }
@@ -381,7 +381,7 @@ article {
   outline: 1px solid var(--content-panel-border);
 }
 
-@media (max-width: 540px) {
+@media (max-width: 556px) {
   article {
     border-radius: 12px;
   }
@@ -574,7 +574,7 @@ article footer button:focus-visible {
 }
 
 [data-block="video"] iframe {
-  --post-width: min(540px, 100vw);
+  --post-width: min(556px, 100vw);
   height: calc(var(--post-width) * var(--aspect-ratio, calc(9 / 16)));
 }
 

--- a/src/outbox.css
+++ b/src/outbox.css
@@ -110,7 +110,7 @@ ol {
 figure,
 audio,
 video {
-  margin: 0 0 4px;
+  margin: 0 0 var(--space-xxs);
 }
 
 /* Page layout */
@@ -525,8 +525,13 @@ article footer button:focus-visible {
 [data-block="audio"],
 [data-block="video"] {
   max-width: none;
-  margin-left: calc(0px - var(--space-m));
-  margin-right: calc(0px - var(--space-m));
+  margin-inline: calc(0px - var(--space-xs));
+}
+
+[data-block="link"],
+[data-block="audio"],
+[data-block="video"] {
+  margin-block: 10px;
 }
 
 [data-row] > [data-block] {
@@ -540,14 +545,13 @@ article footer button:focus-visible {
 
 [data-block="image"] figcaption {
   padding-inline: var(--space-m);
-  margin-block: var(--space-xs);
+  margin-block: var(--space-xxs);
 }
 
 [data-block="link"] {
   border: 1px solid var(--content-tint-strong);
   border-radius: 7px;
   overflow: hidden;
-  margin-block: 15px;
   margin-inline: 0;
 }
 
@@ -574,14 +578,14 @@ article footer button:focus-visible {
 }
 
 [data-block="video"] iframe {
-  --post-width: min(556px, 100vw);
-  height: calc(var(--post-width) * var(--aspect-ratio, calc(9 / 16)));
+  --media-width: min(540px, 100vw);
+  height: calc(var(--media-width) * var(--aspect-ratio, calc(9 / 16)));
 }
 
 :is([data-attribution="post"], [data-attribution="link"], [data-attribution="app"]) {
   display: block;
   padding-inline: var(--space-xs);
-  margin-block: var(--space-xs);
+  margin-block: var(--space-xxs);
   overflow: hidden;
 
   color: var(--content-fg-secondary);

--- a/src/outbox.css
+++ b/src/outbox.css
@@ -541,43 +541,43 @@ article footer button:focus-visible {
 
 [data-block="image"] img {
   display: block;
-  border-radius: 4px;
+  border-radius: 4px; /* Images have rounded corners by default. */
 
   outline: 1px solid var(--content-tint-strong);
   outline-offset: -1px;
 }
 
 [data-block="image"]:has(+ :is([data-row], [data-block="image"])) img {
-  border-bottom-left-radius: 0;
+  border-bottom-left-radius: 0; /* Images with proceedng image blocks or row containers get square bottom corners. */
   border-bottom-right-radius: 0;
 }
 
 :is([data-row], [data-block="image"]) + [data-block="image"] img {
-  border-top-left-radius: 0;
+  border-top-left-radius: 0; /* Images with preceding image blocks or row containers get square top corners. */
   border-top-right-radius: 0;
 }
 
 [data-row] > [data-block="image"] img {
-  border-radius: 4px;
+  border-radius: 4px; /* Reset; images within rows ignore the previous square corner rules. */
 }
 
 [data-row] > [data-block="image"]:has(+ [data-block="image"]) img {
-  border-top-right-radius: 0;
+  border-top-right-radius: 0; /* Images within rows with a proceeding image get square right corners. */
   border-bottom-right-radius: 0;
 }
 
 [data-row] > [data-block="image"] + [data-block="image"] img {
-  border-top-left-radius: 0;
+  border-top-left-radius: 0; /* Images within rows with a preceding image get square left corners. */
   border-bottom-left-radius: 0;
 }
 
 [data-row]:has(+ :is([data-row], [data-block="image"])) > [data-block="image"] img {
-  border-bottom-left-radius: 0;
+  border-bottom-left-radius: 0; /* Images within rows that are proceeded by another image or row get square bottom corners. */
   border-bottom-right-radius: 0;
 }
 
 :is([data-row], [data-block="image"]) + [data-row] > [data-block="image"] img {
-  border-top-left-radius: 0;
+  border-top-left-radius: 0; /* Images within rows that are preceded by another image or row get square top corners. */
   border-top-right-radius: 0;
 }
 

--- a/src/outbox.css
+++ b/src/outbox.css
@@ -188,7 +188,7 @@ main[data-show-limit-warning="true"]::before {
 }
 
 /* Single-column layout | 100vw > aside width + main width + (--space-m * 3) */
-@media not (min-width: 888px) {
+@media not (min-width: 904px) {
   #base-container {
     flex-direction: column-reverse;
     align-items: center;
@@ -220,7 +220,7 @@ main[data-show-limit-warning="true"]::before {
 }
 
 /* Multi-column layout | 100vw ≥ aside width + main width + (--space-m * 3) */
-@media (min-width: 888px) {
+@media (min-width: 904px) {
   #base-container {
     flex-direction: row;
     align-items: flex-start;
@@ -247,7 +247,7 @@ main[data-show-limit-warning="true"]::before {
 }
 
 /* Two-column layout | 100vw < (aside width * 2) + main width + (--space-m * 4) */
-@media not (min-width: 1204px) {
+@media not (min-width: 1220px) {
   aside:empty {
     display: none;
   }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
Updates post and media dimensions to match Tumblr's recent-ish non-full-width media redesign, including borders and rounded corners on images and videos.

Diff best viewed per-commit.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->
Before | After
-|-
<img width="2400" height="3840" alt="Screen Shot 2026-08-03 at 13 54 19" src="https://github.com/user-attachments/assets/bdd760ae-3d11-4208-91ae-8babdb69cfb8" /> | <img width="2400" height="3840" alt="Screen Shot 2026-08-03 at 13 54 38" src="https://github.com/user-attachments/assets/3b140da1-5197-4b0c-aed3-27bb6b5989ef" />
<img width="2400" height="3840" alt="Screen Shot 2026-08-03 at 13 54 23" src="https://github.com/user-attachments/assets/6f4994cf-0779-4d57-9f04-871a375d15b8" /> | <img width="2400" height="3840" alt="Screen Shot 2026-08-03 at 13 54 41" src="https://github.com/user-attachments/assets/2f70b69e-c593-4561-b262-6cc835660b46" />
<img width="2400" height="3840" alt="Screen Shot 2026-08-03 at 13 52 17" src="https://github.com/user-attachments/assets/1eae399f-159f-40e4-8b0d-1078570db953" /> | <img width="2400" height="3840" alt="Screen Shot 2026-08-03 at 13 54 49" src="https://github.com/user-attachments/assets/f8a33cec-e8e9-4d05-867f-a0d4a09c1f18" />
<img width="2400" height="3840" alt="Screen Shot 2026-08-03 at 13 52 26" src="https://github.com/user-attachments/assets/44f7fbc9-ae17-4e5a-ac54-cbb6ad88a104" /> | <img width="2400" height="3840" alt="Screen Shot 2026-08-03 at 13 54 52" src="https://github.com/user-attachments/assets/baeecf1a-c8d9-4c99-826e-a48a9ba4ab08" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a backup file to test with, if applicable.
-->
Smoke-test images and image sets with the addon. Their rounded corner behaviour should match that of Tumblr, i.e. no roundedness on any corner that is adjacent to another image's corner.

Smoke-test audio and video blocks with the addon. Videos should always have rounded corners, no matter the adjacent blocks; audio blocks should never have borders or rounded corners. (Our audio block rendering is... lacking. Even Tumblr's theme engine is better at it now...)