### PR TITLE
feat(UI): render track info for Tumblr-hosted audio

### DIFF
--- a/src/lib/npf.css
+++ b/src/lib/npf.css
@@ -202,3 +202,42 @@
 [data-block="video"] iframe {
   width: 100%;
 }
+
+[data-block="audio"] figcaption {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  height: 85px;
+}
+
+[data-block="audio"] figcaption div {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  min-width: 0;
+  flex: 1;
+  padding-inline: 20px;
+}
+
+[data-block="audio"] figcaption strong,
+[data-block="audio"] figcaption small {
+  line-height: 1.5;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+}
+
+[data-block="audio"] figcaption small {
+  font-size: 75%;
+}
+
+[data-block="audio"] figcaption img {
+  flex-basis: 85px;
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+
+[data-block="audio"] audio {
+  width: 100%;
+}

--- a/src/lib/npf.css
+++ b/src/lib/npf.css
@@ -225,7 +225,7 @@
   line-height: 1.5;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: pre;
+  white-space: nowrap;
 }
 
 [data-block="audio"] figcaption small {

--- a/src/lib/npf.css
+++ b/src/lib/npf.css
@@ -207,7 +207,13 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  align-items: stretch;
   height: 85px;
+}
+
+[data-block="audio"] figcaption div,
+[data-block="audio"] figcaption img {
+  min-width: 0;
 }
 
 [data-block="audio"] figcaption div {
@@ -215,7 +221,6 @@
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
-  min-width: 0;
   flex: 1;
   padding-inline: 20px;
 }
@@ -236,6 +241,7 @@
   flex-basis: 85px;
   flex-grow: 0;
   flex-shrink: 0;
+  object-fit: cover;
 }
 
 [data-block="audio"] audio {

--- a/src/lib/npf.js
+++ b/src/lib/npf.js
@@ -161,6 +161,7 @@ const blockRenderers = {
         album && trackInfo.append(Object.assign(document.createElement('small'), { textContent: album }));
 
         poster && figcaption.append(Object.assign(document.createElement('img'), {
+          loading: 'lazy',
           sizes: '85px',
           srcset: poster.toReversed().map(({ url, width }) => `${url} ${width}w`).join(', ')
         }));

--- a/src/lib/npf.js
+++ b/src/lib/npf.js
@@ -135,12 +135,39 @@ const blockRenderers = {
     });
   },
 
-  audio ({ url, media, title, artist, embedHtml, embed_html = embedHtml, attribution }) {
+  audio ({
+    url,
+    media,
+    title,
+    artist,
+    album,
+    poster,
+    embedHtml,
+    embed_html = embedHtml,
+    attribution
+  }) {
     const figure = document.createElement('figure');
 
     if (embed_html) {
       Object.assign(figure, { innerHTML: embed_html });
     } else if (media) {
+      if (title || artist || album || poster) {
+        const figcaption = document.createElement('figcaption');
+        const trackInfo = document.createElement('div');
+        figcaption.append(trackInfo);
+
+        title && trackInfo.append(Object.assign(document.createElement('strong'), { textContent: title }));
+        artist && trackInfo.append(Object.assign(document.createElement('small'), { textContent: artist }));
+        album && trackInfo.append(Object.assign(document.createElement('small'), { textContent: album }));
+
+        poster && figcaption.append(Object.assign(document.createElement('img'), {
+          sizes: '85px',
+          srcset: poster.toReversed().map(({ url, width }) => `${url} ${width}w`).join(', ')
+        }));
+
+        figure.append(figcaption);
+      }
+
       figure.append(Object.assign(document.createElement('audio'), {
         src: media.url,
         controls: true

--- a/src/outbox.css
+++ b/src/outbox.css
@@ -30,6 +30,7 @@
   --danger: rgba(255, 73, 48, 1);
   --danger-hover: rgba(204, 58, 38, 1);
   --danger-pressed: rgba(153, 44, 29, 1);
+  --brand-purple: rgba(124, 92, 255, 1);
   --brand-orange: rgba(255, 138, 0, 1);
 }
 
@@ -56,6 +57,7 @@
     --danger: rgba(255, 73, 48, 1);
     --danger-hover: rgba(255, 109, 89, 1);
     --danger-pressed: rgba(255, 146, 131, 1);
+    --brand-purple: rgba(124, 92, 255, 1);
     --brand-orange: rgba(255, 138, 0, 1);
   }
 }
@@ -108,7 +110,6 @@ ol {
 }
 
 figure,
-audio,
 video {
   margin: 0 0 var(--space-xxs);
 }
@@ -613,6 +614,18 @@ article footer button:focus-visible {
   font-size: 0.78125rem;
   font-weight: 400;
   text-transform: uppercase;
+}
+
+[data-block="audio"]:has(audio) {
+  border-radius: 8px;
+  overflow: hidden;
+
+  background-color: var(--brand-purple);
+  color: var(--color-fg-light);
+}
+
+[data-block="audio"] figcaption small {
+  font-weight: bold;
 }
 
 [data-block="video"] :is(iframe, video) {

--- a/src/outbox.css
+++ b/src/outbox.css
@@ -25,6 +25,7 @@
   --content-fg-secondary: rgba(76, 94, 114, 1);
   --content-tint: rgba(0, 25, 53, 0.05);
   --content-tint-strong: rgba(0, 25, 53, 0.1);
+  --color-fg: rgba(0, 0, 0, 1);
   --color-fg-light: rgba(255, 255, 255, 1);
   --color-ui-fg: rgba(255, 255, 255, 1);
   --danger: rgba(255, 73, 48, 1);
@@ -53,6 +54,7 @@
     --content-tint: rgba(255, 255, 255, 0.05);
     --content-tint-strong: rgba(255, 255, 255, 0.1);
     --color-fg-light: rgba(255, 255, 255, 1);
+    --color-fg: rgba(0, 0, 0, 1);
     --color-ui-fg: rgba(255, 255, 255, 1);
     --danger: rgba(255, 73, 48, 1);
     --danger-hover: rgba(255, 109, 89, 1);
@@ -626,6 +628,19 @@ article footer button:focus-visible {
 
 [data-block="audio"] figcaption small {
   font-weight: bold;
+}
+
+[data-block="audio"] audio {
+  height: 40px;
+
+  background-color: var(--color-fg);
+  color-scheme: dark;
+}
+
+@supports (selector(audio::-webkit-media-controls-panel)) {
+  [data-block="audio"] audio::-webkit-media-controls-panel {
+    background-color: var(--color-fg);
+  }
 }
 
 [data-block="video"] :is(iframe, video) {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
Adds track info rendering capability to `npf.js`/`npf.css`, and adds further styling to these elements in `outbox.css`.

Browser-native audio players are normalised using Firefox's audio player as a blueprint, just like XKit Rewritten's Vanilla Audio—except, I've chosen to adhere to the Tumblr design system with my colour choice this time, so that it actually contrasts with the post background on dark mode (and thus shows the rounded corners on all sides in both palettes).

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->
Before | After
-|-
<img width="3840" height="2400" alt="Screen Shot 2026-08-04 at 10 58 21" src="https://github.com/user-attachments/assets/ecd2de84-93f0-40d8-b71a-a56c413fd1ec" /> | <img width="3840" height="2400" alt="Screen Shot 2026-08-04 at 10 59 33" src="https://github.com/user-attachments/assets/466e0430-6f11-4c28-b81b-d6f14e83b9a3" />
<img width="3840" height="2400" alt="Screen Shot 2026-08-04 at 10 58 25" src="https://github.com/user-attachments/assets/dcbd88f7-bef0-4f63-bcd9-186f423c1c00" /> | <img width="3840" height="2400" alt="Screen Shot 2026-08-04 at 10 59 39" src="https://github.com/user-attachments/assets/e012edaa-bff9-447e-a2f2-c395a3b24339" />
<img width="3840" height="2400" alt="chrome-extension___kagodfhohnanjlkkgmhhmfeonblbcffa_outbox html" src="https://github.com/user-attachments/assets/efef0dc2-0a36-405d-928f-2f89b050395e" /> | <img width="3840" height="2400" alt="chrome-extension___kagodfhohnanjlkkgmhhmfeonblbcffa_outbox html (2)" src="https://github.com/user-attachments/assets/191c465b-84f6-4878-a8d4-9aad05324182" />
<img width="3840" height="2400" alt="chrome-extension___kagodfhohnanjlkkgmhhmfeonblbcffa_outbox html (1)" src="https://github.com/user-attachments/assets/01c8d2dd-96cd-4fc4-a239-97979c29e8f0" /> | <img width="3840" height="2400" alt="chrome-extension___kagodfhohnanjlkkgmhhmfeonblbcffa_outbox html (3)" src="https://github.com/user-attachments/assets/235cc8d6-c306-4641-bd41-770ed435a155" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a backup file to test with, if applicable.
-->
Load the modified addon and smoke-test audio blocks:
- Audio embeds (e.g. Bandcamp players) shouldn't render any differently from before
- Tumblr-hosted audio should have the new look, with all of the normal metadata that Redpop displays
- Audio blocks for Tumblr-hosted audio with no metadata to display should not render empty trackinfo, just a player
- A long track title/artist/album (or normal-sized on a very narrow viewport) should be clipped with an ellipsis, rather than being able to flow onto multiple lines

Repeat for all other browsers you have access to. We don't support Safari, but it would be nice if it wasn't broken on Safari, if we can help it...?