### PR TITLE
fix(UI): add spacing after last content block in ask

### DIFF
--- a/src/outbox.css
+++ b/src/outbox.css
@@ -456,6 +456,13 @@ article section.error {
   content: "";
 }
 
+.ask::after {
+  display: block;
+  margin-block-start: var(--space-s);
+
+  content: "";
+}
+
 .ask-avatar {
   border-radius: 3px;
 }
@@ -538,8 +545,7 @@ article footer button:focus-visible {
 }
 
 [data-row] > [data-block] {
-  margin-left: 0;
-  margin-right: 0;
+  margin-inline: 0;
 }
 
 [data-block="image"] img {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
Okay, _this_ is the last thing before a v2.3.0 release.

Adds 12px of minimum mandatory spacing between the last block in the ask layout and the end of the ask render box. This is achieved via setting `margin` on an `::after` pseudo-element, so that it collapses into existing margin of rendered blocks themselves. Ergo, this only affects asks which end with a non-text media block or a row.

Mainly, this stops image blocks in ask layouts from having stupid-looking spacing.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->
Before | After
-|-
<img width="3840" height="2400" alt="Screen Shot 2026-08-07 at 16 15 10" src="https://github.com/user-attachments/assets/29bbb0e0-b9ca-4559-b1c7-921dc270c7b8" /> | <img width="3840" height="2400" alt="Screen Shot 2026-08-07 at 16 15 40" src="https://github.com/user-attachments/assets/33f36bc4-c59e-4e42-aa4c-ef33f3d1f53f" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a backup file to test with, if applicable.
-->
Load the modified addon, and check how each block type renders as the last visible child in an ask layout:
- Text blocks should have the same gap (15px)
- Image blocks should have a much bigger gap (4px &rarr; 12px)
- Image rows should have a much bigger gap (4px &rarr; 12px)
- Link blocks should have a slightly bigger gap (10px &rarr; 12px)
- Audio blocks should have a slightly bigger gap (10px &rarr; 12px)
- Video blocks should have a slightly bigger gap (10px &rarr; 12px)
